### PR TITLE
Update Easing interface

### DIFF
--- a/src/animatedRe.re
+++ b/src/animatedRe.re
@@ -30,11 +30,14 @@ module Easing = {
   [@bs.module "react-native"] [@bs.scope "Easing"] external ease : t = "";
   [@bs.module "react-native"] [@bs.scope "Easing"] external exp : t = "";
   [@bs.module "react-native"] [@bs.scope "Easing"] external linear : t = "";
-  [@bs.module "react-native"] [@bs.scope "Easing"] external poly : t = "";
+  [@bs.module "react-native"] [@bs.scope "Easing"]
+  external poly : float => t = "";
   [@bs.module "react-native"] [@bs.scope "Easing"] external quad : t = "";
   [@bs.module "react-native"] [@bs.scope "Easing"] external sin : t = "";
-  [@bs.module "react-native"] [@bs.scope "Easing"] external step0 : t = "";
-  [@bs.module "react-native"] [@bs.scope "Easing"] external step1 : t = "";
+  [@bs.module "react-native"] [@bs.scope "Easing"]
+  external step0 : float => int = "";
+  [@bs.module "react-native"] [@bs.scope "Easing"]
+  external step1 : float => int = "";
   [@bs.module "react-native"] [@bs.scope "Easing"]
   external back : float => t = "";
   [@bs.module "react-native"] [@bs.scope "Easing"]

--- a/src/animatedRe.rei
+++ b/src/animatedRe.rei
@@ -24,11 +24,11 @@ module Easing: {
   let ease: t;
   let exp: t;
   let linear: t;
-  let poly: t;
+  let poly: float => t;
   let quad: t;
   let sin: t;
-  let step0: t;
-  let step1: t;
+  let step0: float => int;
+  let step1: float => int;
   let back: float => t;
   let elastic: float => t;
   let in_: t => t;


### PR DESCRIPTION
This pull request updates type signature of 3 methods of `Easing` module, making it easy to now write `Easing.poly(5)` and use it as an easing function.

The previous definition was wrong and prevent us from using it within `rebolt-navigation`.