### PR TITLE
Animated improvements

### DIFF
--- a/docs/animated.md
+++ b/docs/animated.md
@@ -196,3 +196,5 @@ let make = _children => {
 ## reset
 
 # Easing
+
+This module is exposed under `Animated` for historical reasons. Please see [`Easing`](/docs/easing.html) module instead.

--- a/docs/animated.md
+++ b/docs/animated.md
@@ -327,8 +327,10 @@ See available configuration below:
 #### deceleration
 
 ```reason
-
+~deceleration: float=?
 ```
+
+### Composition
 
 Animations presented in the previous section can be combined all together in many complex ways using the following API.
 

--- a/docs/animated.md
+++ b/docs/animated.md
@@ -3,3 +3,132 @@ id: animated
 title: Animated
 sidebar_label: Animated
 ---
+
+## Example of use
+
+`Animated` allows to create declarative animations that are fluid, powerful and easy to build.
+
+### basic
+
+The simplest animation starts with creating an animated value and using one of the built-in animations to change its value over time.
+
+The following example demonstrates use of `Animated.Timing` in order to animate an animated value throughout given period of time.
+
+```reason
+open Rebolt;
+
+let animatedValue = Animated.Value.create(0.0);
+
+let animation =
+  Animated.Timing.animate(
+    ~value=animatedValue,
+    ~toValue=`raw(1.0),
+    ~duration=100.0,
+    (),
+  );
+
+Animated.CompositeAnimation.start(animation, ~callback=_didFinish => (), ());
+```
+
+### multiple
+
+Animations can be also combined together in complex ways using composition functions.
+
+The following example demonstrates use of `Animated.sequence` in order to run animations in a sequence, one by one.
+
+```reason
+open Rebolt;
+
+let animatedValue = Animated.Value.create(0.0);
+
+let animation =
+  Animated.sequence([|
+    Animated.Timing.animate(
+      ~value=animatedValue,
+      ~toValue=`raw(1.0),
+      ~duration=100.0,
+      (),
+    ),
+    Animated.Timing.animate(
+      ~value=animatedValue,
+      ~toValue=`raw(0.0),
+      ~duration=100.0,
+      (),
+    ),
+  |]);
+
+Animated.CompositeAnimation.start(animation, ~callback=_didFinish => (), ());
+```
+
+### calculation
+
+You can combine two animated values via addition, multiplication, division, or modulo to make a new animated value.
+
+The following example demonstrates use of `Animated.multiply` in order to reverse the value of the `animatedValue`.
+
+```reason
+open Rebolt;
+
+let animatedValue = Animated.Value.create(0.0);
+
+let newAnimatedValue = Animated.multiply(animatedValue, Animated.Value.create(-1.0));
+```
+
+Keep in mind that calculated values (such as `newAnimatedValue` from the snippet above) cannot be animated. Trying to pass them to any of the animated functions will result in a type error.
+
+### interpolation
+
+You can interpolate an animated value in order to bind to its value and change the output.
+
+The following example demonstrates interpolation in order to map values of an animated value to the opacity of a container.
+
+```reason
+let animatedValue = Animated.Value.create(100.0);
+
+let animatedOpacity =
+	Animated.Value.interpolate(
+		animatedValue,
+		~inputRange=[0.0, 100.0],
+		~outputRange=`float([0.0, 1.0]),
+		~extrapolate=Animated.Interpolation.Clamp,
+		(),
+	);
+```
+
+### styling
+
+Animated values can be passed to an animated component in order to change its apperance as the animated value changes.
+
+The example below demonstrates animating opacity of a component.
+
+```reason
+open Rebolt;
+
+let animatedValue = Animated.Value.create(0.0);
+
+let component = ReasonReact.statelessComponent("MyComponent");
+
+let containerStyle = Style.(
+	style([
+	  opacity(Animated(animatedValue))
+		flex(1.0)
+	])
+);
+
+let make = _children => {
+  ...component,
+	didMount: _self => {
+		Animated.CompositeAnimation.start(
+			Animated.Timing.animate(
+				~value=animatedValue,
+				~toValue=`raw(1.0),
+				~duration=100.0,
+				(),
+			),
+			~callback=_didFinish => (),
+			()
+		);
+	},
+  render: _self => <Animated.View style=containerStyle />,
+};
+```

--- a/docs/animated.md
+++ b/docs/animated.md
@@ -86,13 +86,13 @@ The following example demonstrates interpolation in order to map values of an an
 let animatedValue = Animated.Value.create(100.0);
 
 let animatedOpacity =
-	Animated.Value.interpolate(
-		animatedValue,
-		~inputRange=[0.0, 100.0],
-		~outputRange=`float([0.0, 1.0]),
-		~extrapolate=Animated.Interpolation.Clamp,
-		(),
-	);
+  Animated.Value.interpolate(
+    animatedValue,
+    ~inputRange=[0.0, 100.0],
+    ~outputRange=`float([0.0, 1.0]),
+    ~extrapolate=Animated.Interpolation.Clamp,
+    (),
+  );
 ```
 
 ### styling
@@ -109,26 +109,26 @@ let animatedValue = Animated.Value.create(0.0);
 let component = ReasonReact.statelessComponent("MyComponent");
 
 let containerStyle = Style.(
-	style([
-	  opacity(Animated(animatedValue))
-		flex(1.0)
-	])
+  style([
+    opacity(Animated(animatedValue))
+    flex(1.0)
+  ])
 );
 
 let make = _children => {
   ...component,
-	didMount: _self => {
-		Animated.CompositeAnimation.start(
-			Animated.Timing.animate(
-				~value=animatedValue,
-				~toValue=`raw(1.0),
-				~duration=100.0,
-				(),
-			),
-			~callback=_didFinish => (),
-			()
-		);
-	},
+  didMount: _self => {
+    Animated.CompositeAnimation.start(
+      Animated.Timing.animate(
+        ~value=animatedValue,
+        ~toValue=`raw(1.0),
+        ~duration=100.0,
+        (),
+      ),
+      ~callback=_didFinish => (),
+      ()
+    );
+  },
   render: _self => <Animated.View style=containerStyle />,
 };
 ```

--- a/docs/animated.md
+++ b/docs/animated.md
@@ -27,7 +27,7 @@ let animation =
     (),
   );
 
-Animated.Animation.start(animation, ~callback=_didFinish => (), ());
+Animated.start(animation, ~callback=_didFinish => (), ());
 ```
 
 ### multiple
@@ -57,7 +57,7 @@ let animation =
     ),
   |]);
 
-Animated.Animation.start(animation, ~callback=_didFinish => (), ());
+Animated.start(animation, ~callback=_didFinish => (), ());
 ```
 
 ### calculation
@@ -118,7 +118,7 @@ let containerStyle = Style.(
 let make = _children => {
   ...component,
   didMount: _self => {
-    Animated.Animation.start(
+    Animated.start(
       Animated.timing(
         ~value=animatedValue,
         ~toValue=`raw(1.0),
@@ -132,6 +132,10 @@ let make = _children => {
   render: _self => <Animated.View style=containerStyle />,
 };
 ```
+
+### event
+
+### custom component
 
 ## Animations
 
@@ -185,7 +189,7 @@ let animation = Animated.spring(
   (),
 );
 
-Animated.Animation.start(animation, ~callback=_didFinish => (), ());
+Animated.start(animation, ~callback=_didFinish => (), ());
 ```
 
 See available configuration below:
@@ -270,7 +274,7 @@ let animation = Animated.timing(
   (),
 );
 
-Animated.Animation.start(animation, ~callback=_didFinish => (), ());
+Animated.start(animation, ~callback=_didFinish => (), ());
 ```
 
 See available configuration below:
@@ -309,7 +313,7 @@ let animation = Animated.decay(
   (),
 );
 
-Animated.Animation.start(animation, ~callback=_didFinish => (), ());
+Animated.start(animation, ~callback=_didFinish => (), ());
 ```
 
 See available configuration below:
@@ -365,7 +369,7 @@ let animation =
     {"stopTogether": false},
   );
 
-Animated.Animation.start(animation, ~callback=_didFinish => (), ());
+Animated.start(animation, ~callback=_didFinish => (), ());
 ```
 
 When `stopTogether` is set to `true`, `callback` passed to `Animation.start` will get executed only once, after all animations within the array have finished. Otherwise, it may get executed many times. You should check for the value of `didFinish` boolean that is the first argument to the callback function.
@@ -403,7 +407,7 @@ let animation =
     |],
   );
 
-Animated.Animation.start(animation, ~callback=_didFinish => (), ());
+Animated.start(animation, ~callback=_didFinish => (), ());
 ```
 
 ### delay
@@ -433,7 +437,7 @@ let animation =
     {"stopTogether": false},
   );
 
-Animated.Animation.start(animation, ~callback=_didFinish => (), ());
+Animated.start(animation, ~callback=_didFinish => (), ());
 ```
 
 The above example will delay the `barValue` animation by 500 milliseconds.
@@ -479,7 +483,7 @@ let animation =
     (),
   );
 
-Animated.Animation.start(animation, ~callback=_didFinish => (), ());
+Animated.start(animation, ~callback=_didFinish => (), ());
 ```
 
 ## Animated.Value
@@ -618,11 +622,11 @@ type extrapolate =
   | Identity;
 ```
 
-## Animation
+## Animating
 
-This module can be used to start, stop and reset animations created in the previous sections.
+Following API can be used to control the animations.
 
-### start
+## start
 
 ```reason
 let start: (Animation.t, ~callback: Animation.endCallback=?, unit) => unit;
@@ -630,7 +634,7 @@ let start: (Animation.t, ~callback: Animation.endCallback=?, unit) => unit;
 
 Starts an animation
 
-### stop
+## stop
 
 ```reason
 let stop: (Animation.t) => unit;
@@ -638,7 +642,7 @@ let stop: (Animation.t) => unit;
 
 Stops an animation
 
-### reset
+## reset
 
 ```reason
 let reset: (Animation.t) => unit;

--- a/docs/animated.md
+++ b/docs/animated.md
@@ -132,3 +132,67 @@ let make = _children => {
   render: _self => <Animated.View style=containerStyle />,
 };
 ```
+
+# Animations
+
+## Spring
+
+## Timing
+
+## Decay
+
+# Composition
+
+## parallel
+
+## stagger
+
+## delay
+
+## sequence
+
+## loop
+
+# Animated.Value
+
+## create
+
+## add
+
+## divide
+
+## multiply
+
+## diffClamp
+
+## modulo
+
+## interpolate
+
+## setValue
+
+## setOffset
+
+## flattenOffset
+
+## extractOffset
+
+## addListener
+
+## removeListener
+
+## removeAllListeners
+
+## stopTracking
+
+## track
+
+# CompositeAnimation
+
+## start
+
+## stop
+
+## reset
+
+# Easing

--- a/docs/animated.md
+++ b/docs/animated.md
@@ -370,7 +370,7 @@ let animation =
 Animated.start(animation, ~callback=_didFinish => (), ());
 ```
 
-When `stopTogether` is set to `true`, `callback` passed to `Animation.start` will get executed only once, after all animations within the array have finished. Otherwise, it may get executed many times. You should check for the value of `didFinish` boolean that is the first argument to the callback function.
+When `stopTogether` is set to `true`, `callback` passed to `Animated.start` will get executed only once, after all animations within the array have finished. Otherwise, it may get executed many times. You should check for the value of `didFinish` boolean that is the first argument to the callback function.
 
 ### stagger
 

--- a/docs/animated.md
+++ b/docs/animated.md
@@ -27,7 +27,7 @@ let animation =
     (),
   );
 
-Animated.start(animation, ~callback=_didFinish => (), ());
+Animated.start(animation, ());
 ```
 
 ### multiple
@@ -57,7 +57,7 @@ let animation =
     ),
   |]);
 
-Animated.start(animation, ~callback=_didFinish => (), ());
+Animated.start(animation, ());
 ```
 
 ### calculation
@@ -189,7 +189,7 @@ let animation = Animated.spring(
   (),
 );
 
-Animated.start(animation, ~callback=_didFinish => (), ());
+Animated.start(animation, ());
 ```
 
 See available configuration below:
@@ -274,7 +274,7 @@ let animation = Animated.timing(
   (),
 );
 
-Animated.start(animation, ~callback=_didFinish => (), ());
+Animated.start(animation, ());
 ```
 
 See available configuration below:
@@ -313,7 +313,7 @@ let animation = Animated.decay(
   (),
 );
 
-Animated.start(animation, ~callback=_didFinish => (), ());
+Animated.start(animation, ());
 ```
 
 See available configuration below:
@@ -369,7 +369,7 @@ let animation =
     {"stopTogether": false},
   );
 
-Animated.start(animation, ~callback=_didFinish => (), ());
+Animated.start(animation, ());
 ```
 
 When `stopTogether` is set to `true`, `callback` passed to `Animated.start` will get executed only once, after all animations within the array have finished. Otherwise, it may get executed many times. You should check for the value of `didFinish` boolean that is the first argument to the callback function.
@@ -407,7 +407,7 @@ let animation =
     |],
   );
 
-Animated.start(animation, ~callback=_didFinish => (), ());
+Animated.start(animation, ());
 ```
 
 ### delay
@@ -437,7 +437,7 @@ let animation =
     {"stopTogether": false},
   );
 
-Animated.start(animation, ~callback=_didFinish => (), ());
+Animated.start(animation, ());
 ```
 
 The above example will delay the `barValue` animation by 500 milliseconds.
@@ -483,7 +483,7 @@ let animation =
     (),
   );
 
-Animated.start(animation, ~callback=_didFinish => (), ());
+Animated.start(animation, ());
 ```
 
 ## Animated.Value
@@ -632,7 +632,7 @@ Following API can be used to control the animations.
 let start: (Animation.t, ~callback: Animation.endCallback=?, unit) => unit;
 ```
 
-Starts an animation
+Starts an animation.
 
 ## stop
 

--- a/docs/animated.md
+++ b/docs/animated.md
@@ -133,68 +133,68 @@ let make = _children => {
 };
 ```
 
-# Animations
+### Animations
 
-## Spring
+### Spring
 
-## Timing
+### Timing
 
-## Decay
+### Decay
 
-# Composition
+## Composition
 
-## parallel
+### parallel
 
-## stagger
+### stagger
 
-## delay
+### delay
 
-## sequence
+### sequence
 
-## loop
+### loop
 
-# Animated.Value
+## Animated.Value
 
-## create
+### create
 
-## add
+### add
 
-## divide
+### divide
 
-## multiply
+### multiply
 
-## diffClamp
+### diffClamp
 
-## modulo
+### modulo
 
-## interpolate
+### interpolate
 
-## setValue
+### setValue
 
-## setOffset
+### setOffset
 
-## flattenOffset
+### flattenOffset
 
-## extractOffset
+### extractOffset
 
-## addListener
+### addListener
 
-## removeListener
+### removeListener
 
-## removeAllListeners
+### removeAllListeners
 
-## stopTracking
+### stopTracking
 
-## track
+### track
 
-# CompositeAnimation
+## CompositeAnimation
 
-## start
+### start
 
-## stop
+### stop
 
-## reset
+### reset
 
-# Easing
+## Easing
 
 This module is exposed under `Animated` for historical reasons. Please see [`Easing`](/docs/easing.html) module instead.

--- a/docs/animated.md
+++ b/docs/animated.md
@@ -135,7 +135,116 @@ let make = _children => {
 
 ### Animations
 
+Animated provides three types of animation types. Each animation type provides a particular animation curve that controls how your values animate from their initial value to the final value.
+
+### Configuration
+
+Below is the list of common configuration options applicable to all below animations.
+
+#### toValue
+
+```reason
+~toValue: [ | `raw(float) | `animated(Animated.value))]
+```
+
+#### value
+
+```reason
+~value: Animated.value
+```
+
+#### useNativeDriver
+
+```reason
+~useNativeDriver: bool=?
+```
+
+#### iterations
+
+```reason
+~iterations: int=?
+```
+
 ### Spring
+
+Provides a simple spring physics model.
+
+```reason
+let animation = Animated.Spring.animate(
+	~value=animatedValue,
+	~toValue=`raw(1.0),
+	~bounciness=5.0,
+	(),
+);
+```
+
+See available configuration below:
+
+#### restDisplacementThreshold
+
+```reason
+~restDisplacementThreshold: float=?
+```
+
+#### overshootClamping
+
+```reason
+~overshootClamping: bool=?
+```
+
+#### restSpeedThreshold
+
+```reason
+~restSpeedThreshold: float=?
+```
+
+#### velocity
+
+```reason
+~velocity: float=?
+```
+
+#### bounciness
+
+```reason
+~bounciness: float=?
+```
+
+#### speed
+
+```reason
+~speed: float=?
+```
+
+#### tension
+
+```reason
+~tension: float=?
+```
+
+#### friction
+
+```reason
+~friction: float=?
+```
+
+#### stiffness
+
+```reason
+~stiffness: float=?
+```
+
+#### mass
+
+```reason
+~mass: float=?
+```
+
+#### damping
+
+```reason
+~damping: float=?
+```
 
 ### Timing
 

--- a/docs/animated.md
+++ b/docs/animated.md
@@ -484,37 +484,139 @@ Animated.CompositeAnimation.start(animation, ~callback=_didFinish => (), ());
 
 ## Animated.Value
 
+There are few types of Animated values present in React Native codebase. Not all operations are permitted on all of them.
+
+To prevent mistakes in user land and provide type safety, Rebolt uses phantom types to distinguish between different types of values:
+
+- `Animated.value(regular)` - created with `Animated.Value.create`. Can be animated, interpolated as well as used for math operations
+
+- `Animated.value(calculated)` - dynamic value created either by interpolating another animated value or by using math operations. Cannot be animated, because it's not a root animated value.
+
+In the below documentation, `Animated.value('a)` means that any animated value can be used.
+
 ### create
+
+```reason
+let create: float => Animated.Value.t;
+```
+
+Creates a new animated value.
 
 ### add
 
+```reason
+let add : (Animated.value('a), Animated.value('b)) => Animated.value(calculated);
+```
+
 ### divide
+
+```reason
+let divide : (Animated.value('a), Animated.value('b)) => Animated.value(calculated) = "";
+```
 
 ### multiply
 
+```reason
+let multiply : (Animated.value('a), Animated.value('b)) => Animated.value(calculated) = "";
+```
+
 ### diffClamp
+
+```reason
+let diffClamp : (Animated.value('a), float, float) => Animated.value(calculated) = "";
+```
 
 ### modulo
 
+```reason
+let diffClamp : (Animated.value('a), float) => Animated.value(calculated) = "";
+```
+
 ### interpolate
+
+Shorthand for [Animated.Interpolation.interpolate](#interpolation).
 
 ### setValue
 
+```reason
+let setValue: (t, float) => unit;
+```
+
 ### setOffset
+
+```reason
+let setOffset: (t, float) => unit;
+```
 
 ### flattenOffset
 
+```reason
+let flattenOffset: t => unit;
+```
+
 ### extractOffset
+
+```reason
+let extractOffset: t => unit;
+```
 
 ### addListener
 
+```reason
+let addListener: (t, callback) => string;
+```
+
 ### removeListener
+
+```reason
+let removeListener: (t, string) => unit;
+```
 
 ### removeAllListeners
 
+```reason
+let removeAllListeners: t => unit;
+```
+
 ### stopTracking
 
+```reason
+let removeAllListeners: t => unit;
+```
+
 ### track
+
+```reason
+let track: t => unit;
+```
+
+## Interpolation
+
+### interpolate
+
+```reason
+let interpolate:
+  (
+    Animated.value('a),
+    ~inputRange: list(float),
+    ~outputRange: [< | `float(list(float)) | `string(list(string))],
+    ~easing: Easing.t=?,
+    ~extrapolate: Interpolation.extrapolate=?,
+    ~extrapolateLeft: Interpolation.extrapolate=?,
+    ~extrapolateRight: Interpolation.extrapolate=?,
+    unit
+  ) =>
+ Animated.value(calculated)
+```
+
+### extrapolate
+
+```reason
+type extrapolate =
+  | Extend
+  | Clamp
+  | Identity;
+```
 
 ## CompositeAnimation
 
@@ -523,7 +625,7 @@ All animations created with [Animations](#animations) or [Composition](#composit
 ### start
 
 ```reason
-let start = (CompositeAnimation.t, ~callback: Animation.endCallback=?, unit) => unit;
+let start: (CompositeAnimation.t, ~callback: Animation.endCallback=?, unit) => unit;
 ```
 
 Starts an animation
@@ -531,7 +633,7 @@ Starts an animation
 ### stop
 
 ```reason
-let stop = (CompositeAnimation.t) => unit;
+let stop: (CompositeAnimation.t) => unit;
 ```
 
 Stops an animation
@@ -539,7 +641,7 @@ Stops an animation
 ### reset
 
 ```reason
-let reset = (CompositeAnimation.t) => unit;
+let reset: (CompositeAnimation.t) => unit;
 ```
 
 Resets an animation
@@ -547,7 +649,3 @@ Resets an animation
 ## Easing
 
 This module is exposed under `Animated` for historical reasons. Please see [`Easing`](/docs/easing.html) module instead.
-
-```
-
-```

--- a/docs/animated.md
+++ b/docs/animated.md
@@ -133,7 +133,7 @@ let make = _children => {
 };
 ```
 
-### Animations
+## Animations
 
 Animated provides three types of animation types. Each animation type provides a particular animation curve that controls how your values animate from their initial value to the final value.
 
@@ -165,16 +165,24 @@ Below is the list of common configuration options applicable to all below animat
 ~iterations: int=?
 ```
 
+#### isInteraction
+
+```reason
+~isInteraction: bool=?
+```
+
 ### Spring
 
 Provides a simple spring physics model.
 
 ```reason
+let animatedValue = Animated.Value.create(0.0);
+
 let animation = Animated.Spring.animate(
-	~value=animatedValue,
-	~toValue=`raw(1.0),
-	~bounciness=5.0,
-	(),
+  ~value=animatedValue,
+  ~toValue=`raw(1.0),
+  ~bounciness=5.0,
+  (),
 );
 ```
 
@@ -248,7 +256,69 @@ See available configuration below:
 
 ### Timing
 
+Animates a value over time using easing functions.
+
+```reason
+let animatedValue = Animated.Value.create(0.0);
+
+let animation = Animated.Timing.animate(
+  ~value=animatedValue,
+  ~toValue=`raw(1.0),
+  ~duration=100.0,
+  (),
+);
+```
+
+See available configuration below:
+
+#### easing
+
+```reason
+~easing: Easing.t=?
+```
+
+Easing function. See [Easing](/docs/easing.html) for available options.
+
+#### duration
+
+```reason
+~duration: float=?
+```
+
+#### delay
+
+```reason
+~delay: float=?
+```
+
 ### Decay
+
+Starts with an initial velocity and gradually slows to a stop.
+
+```reason
+let animatedValue = Animated.Value.create(0.0);
+
+let animation = Animated.Decay.animate(
+  ~value=animatedValue,
+  ~toValue=`raw(1.0),
+  ~velocity=100.0,
+  (),
+);
+```
+
+See available configuration below:
+
+#### velocity
+
+```reason
+~velocity: float
+```
+
+#### deceleration
+
+```reason
+~deceleration: float=?
+```
 
 ## Composition
 

--- a/docs/animated.md
+++ b/docs/animated.md
@@ -20,14 +20,14 @@ open Rebolt;
 let animatedValue = Animated.Value.create(0.0);
 
 let animation =
-  Animated.Timing.animate(
+  Animated.timing(
     ~value=animatedValue,
     ~toValue=`raw(1.0),
     ~duration=100.0,
     (),
   );
 
-Animated.CompositeAnimation.start(animation, ~callback=_didFinish => (), ());
+Animated.Animation.start(animation, ~callback=_didFinish => (), ());
 ```
 
 ### multiple
@@ -43,13 +43,13 @@ let animatedValue = Animated.Value.create(0.0);
 
 let animation =
   Animated.sequence([|
-    Animated.Timing.animate(
+    Animated.timing(
       ~value=animatedValue,
       ~toValue=`raw(1.0),
       ~duration=100.0,
       (),
     ),
-    Animated.Timing.animate(
+    Animated.timing(
       ~value=animatedValue,
       ~toValue=`raw(0.0),
       ~duration=100.0,
@@ -57,7 +57,7 @@ let animation =
     ),
   |]);
 
-Animated.CompositeAnimation.start(animation, ~callback=_didFinish => (), ());
+Animated.Animation.start(animation, ~callback=_didFinish => (), ());
 ```
 
 ### calculation
@@ -118,8 +118,8 @@ let containerStyle = Style.(
 let make = _children => {
   ...component,
   didMount: _self => {
-    Animated.CompositeAnimation.start(
-      Animated.Timing.animate(
+    Animated.Animation.start(
+      Animated.timing(
         ~value=animatedValue,
         ~toValue=`raw(1.0),
         ~duration=100.0,
@@ -171,21 +171,21 @@ Below is the list of common configuration options applicable to all below animat
 ~isInteraction: bool=?
 ```
 
-### Spring
+### spring
 
 Provides a simple spring physics model.
 
 ```reason
 let animatedValue = Animated.Value.create(0.0);
 
-let animation = Animated.Spring.animate(
+let animation = Animated.spring(
   ~value=animatedValue,
   ~toValue=`raw(1.0),
   ~bounciness=5.0,
   (),
 );
 
-Animated.CompositeAnimation.start(animation, ~callback=_didFinish => (), ());
+Animated.Animation.start(animation, ~callback=_didFinish => (), ());
 ```
 
 See available configuration below:
@@ -263,14 +263,14 @@ Animates a value over time using easing functions.
 ```reason
 let animatedValue = Animated.Value.create(0.0);
 
-let animation = Animated.Timing.animate(
+let animation = Animated.timing(
   ~value=animatedValue,
   ~toValue=`raw(1.0),
   ~duration=100.0,
   (),
 );
 
-Animated.CompositeAnimation.start(animation, ~callback=_didFinish => (), ());
+Animated.Animation.start(animation, ~callback=_didFinish => (), ());
 ```
 
 See available configuration below:
@@ -295,21 +295,21 @@ Easing function. See [Easing](/docs/easing.html) for available options.
 ~delay: float=?
 ```
 
-### Decay
+### decay
 
 Starts with an initial velocity and gradually slows to a stop.
 
 ```reason
 let animatedValue = Animated.Value.create(0.0);
 
-let animation = Animated.Decay.animate(
+let animation = Animated.decay(
   ~value=animatedValue,
   ~toValue=`raw(1.0),
   ~velocity=100.0,
   (),
 );
 
-Animated.CompositeAnimation.start(animation, ~callback=_didFinish => (), ());
+Animated.Animation.start(animation, ~callback=_didFinish => (), ());
 ```
 
 See available configuration below:
@@ -334,8 +334,8 @@ Animations presented in the previous section can be combined all together in man
 
 ```reason
 let parallel:
-  (array(CompositeAnimation.t), {. "stopTogether": bool}) =>
-  CompositeAnimation.t;
+  (array(Animation.t), {. "stopTogether": bool}) =>
+  Animation.t;
 ```
 
 Runs an array of animations in parallel.
@@ -349,13 +349,13 @@ let barValue = Animated.Value.create(0.0);
 let animation =
   Animated.parallel(
     [|
-      Animated.Timing.animate(
+      Animated.timing(
         ~value=fooValue,
         ~toValue=`raw(1.0),
         ~duration=100.0,
         (),
       ),
-      Animated.Timing.animate(
+      Animated.timing(
         ~value=barValue,
         ~toValue=`raw(0.0),
         ~duration=100.0,
@@ -365,15 +365,15 @@ let animation =
     {"stopTogether": false},
   );
 
-Animated.CompositeAnimation.start(animation, ~callback=_didFinish => (), ());
+Animated.Animation.start(animation, ~callback=_didFinish => (), ());
 ```
 
-When `stopTogether` is set to `true`, `callback` passed to `CompositeAnimation.start` will get executed only once, after all animations within the array have finished. Otherwise, it may get executed many times. You should check for the value of `didFinish` boolean that is the first argument to the callback function.
+When `stopTogether` is set to `true`, `callback` passed to `Animation.start` will get executed only once, after all animations within the array have finished. Otherwise, it may get executed many times. You should check for the value of `didFinish` boolean that is the first argument to the callback function.
 
 ### stagger
 
 ```reason
-let stagger: (float, array(CompositeAnimation.t)) => CompositeAnimation.t;
+let stagger: (float, array(Animation.t)) => Animation.t;
 ```
 
 Array of animations may run in parallel (overlap), but are started in sequence with successive delays.
@@ -388,13 +388,13 @@ let animation =
   Animated.stagger(
     50.0,
     [|
-      Animated.Timing.animate(
+      Animated.timing(
         ~value=fooValue,
         ~toValue=`raw(1.0),
         ~duration=100.0,
         (),
       ),
-      Animated.Timing.animate(
+      Animated.timing(
         ~value=barValue,
         ~toValue=`raw(0.0),
         ~duration=100.0,
@@ -403,13 +403,13 @@ let animation =
     |],
   );
 
-Animated.CompositeAnimation.start(animation, ~callback=_didFinish => (), ());
+Animated.Animation.start(animation, ~callback=_didFinish => (), ());
 ```
 
 ### delay
 
 ```reason
-let delay: float => CompositeAnimation.t;
+let delay: float => Animation.t;
 ```
 
 Helper function to delay execution of the animation. To be used with other Animated functions, as demonstrated at the below example.
@@ -423,7 +423,7 @@ let animation =
   Animated.sequence(
     [|
       Animated.delay(500),
-      Animated.Timing.animate(
+      Animated.timing(
         ~value=barValue,
         ~toValue=`raw(0.0),
         ~duration=100.0,
@@ -433,7 +433,7 @@ let animation =
     {"stopTogether": false},
   );
 
-Animated.CompositeAnimation.start(animation, ~callback=_didFinish => (), ());
+Animated.Animation.start(animation, ~callback=_didFinish => (), ());
 ```
 
 The above example will delay the `barValue` animation by 500 milliseconds.
@@ -441,7 +441,7 @@ The above example will delay the `barValue` animation by 500 milliseconds.
 ### sequence
 
 ```reason
-let sequence: array(CompositeAnimation.t) => CompositeAnimation.t;
+let sequence: array(Animation.t) => Animation.t;
 ```
 
 Starts an array of animations in order, waiting for each to complete before starting the next. If the current running animation is stopped, no following animations will be started.
@@ -454,8 +454,8 @@ See the example [in the previous section](#delay).
 
 ```reason
 let loop:
-  (~iterations: int=?, ~animation: CompositeAnimation.t, unit) =>
-  CompositeAnimation.t;
+  (~iterations: int=?, ~animation: Animation.t, unit) =>
+  Animation.t;
 ```
 
 Loops a given animation continuously, so that each time it reaches the end, it resets and begins again from the start.
@@ -469,7 +469,7 @@ let fooValue = Animated.Value.create(0.0);
 
 let animation =
   Animated.loop(
-    ~animation=Animated.Timing.animate(
+    ~animation=Animated.timing(
       ~value=fooValue,
       ~toValue=`raw(0.0),
       ~iterations=4,
@@ -479,7 +479,7 @@ let animation =
     (),
   );
 
-Animated.CompositeAnimation.start(animation, ~callback=_didFinish => (), ());
+Animated.Animation.start(animation, ~callback=_didFinish => (), ());
 ```
 
 ## Animated.Value
@@ -618,14 +618,14 @@ type extrapolate =
   | Identity;
 ```
 
-## CompositeAnimation
+## Animation
 
-All animations created with [Animations](#animations) or [Composition](#composition) APIs are an instance of `CompositeAnimation`. This module can be used to start, stop and reset such created objects.
+This module can be used to start, stop and reset animations created in the previous sections.
 
 ### start
 
 ```reason
-let start: (CompositeAnimation.t, ~callback: Animation.endCallback=?, unit) => unit;
+let start: (Animation.t, ~callback: Animation.endCallback=?, unit) => unit;
 ```
 
 Starts an animation
@@ -633,7 +633,7 @@ Starts an animation
 ### stop
 
 ```reason
-let stop: (CompositeAnimation.t) => unit;
+let stop: (Animation.t) => unit;
 ```
 
 Stops an animation
@@ -641,7 +641,7 @@ Stops an animation
 ### reset
 
 ```reason
-let reset: (CompositeAnimation.t) => unit;
+let reset: (Animation.t) => unit;
 ```
 
 Resets an animation

--- a/src/animatedRe.re
+++ b/src/animatedRe.re
@@ -2,25 +2,23 @@ module Animation = {
   type t;
   type endResult = {. "finished": bool};
   type endCallback = endResult => unit;
-};
-
-module type Value = {type t; type rawJsType;};
-
-type calculated;
-type regular;
-type value('a);
-type valueXY('a);
-
-module CompositeAnimation = {
-  type t;
   [@bs.send]
-  external _start : (t, Js.undefined(Animation.endCallback)) => unit =
-    "start";
+  external _start : (t, Js.undefined(endCallback)) => unit = "start";
   let start = (t, ~callback=?, ()) =>
     _start(t, Js.Undefined.fromOption(callback));
   [@bs.send] external stop : t => unit = "";
   [@bs.send] external reset : t => unit = "";
 };
+
+module type Value = {type t; type rawJsType;};
+
+type calculated;
+
+type regular;
+
+type value('a);
+
+type valueXY('a);
 
 module ValueAnimations = (Val: Value) => {
   module Decay = {
@@ -38,7 +36,7 @@ module ValueAnimations = (Val: Value) => {
       config =
       "";
     [@bs.module "react-native"] [@bs.scope "Animated"]
-    external _decay : (Val.t, config) => CompositeAnimation.t = "decay";
+    external _decay : (Val.t, config) => Animation.t = "decay";
     let animate =
         (
           ~value,
@@ -90,7 +88,7 @@ module ValueAnimations = (Val: Value) => {
     external toValueRaw : Val.rawJsType => toValue = "%identity";
     external toValueAnimated : Val.t => toValue = "%identity";
     [@bs.module "react-native"] [@bs.scope "Animated"]
-    external _spring : (Val.t, config) => CompositeAnimation.t = "spring";
+    external _spring : (Val.t, config) => Animation.t = "spring";
     let animate =
         (
           ~value,
@@ -160,7 +158,7 @@ module ValueAnimations = (Val: Value) => {
     external toValueRaw : Val.rawJsType => toValue = "%identity";
     external toValueAnimated : Val.t => toValue = "%identity";
     [@bs.module "react-native"] [@bs.scope "Animated"]
-    external _timing : (Val.t, config) => CompositeAnimation.t = "timing";
+    external _timing : (Val.t, config) => Animation.t = "timing";
     let animate =
         (
           ~value,
@@ -294,10 +292,13 @@ module Value = {
     "animate";
   [@bs.send] external stopTracking : t => unit = "stopTracking";
   [@bs.send] external track : t => unit = "track";
-  include ValueAnimations({
-    type t = value(regular);
-    type rawJsType = float;
-  });
+  include
+    ValueAnimations(
+      {
+        type t = value(regular);
+        type rawJsType = float;
+      },
+    );
   include ValueOperations;
   let interpolate = Interpolation.interpolate;
 };
@@ -342,33 +343,31 @@ module ValueXY = {
     "getTranslateTransform";
   [@bs.get] external getX : t => Value.t = "x";
   [@bs.get] external getY : t => Value.t = "y";
-  include ValueAnimations({
-    type t = valueXY(regular);
-    type rawJsType = jsValue;
-  });
+  include
+    ValueAnimations(
+      {
+        type t = valueXY(regular);
+        type rawJsType = jsValue;
+      },
+    );
 };
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external delay : float => CompositeAnimation.t = "";
+external delay : float => Animation.t = "";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external sequence : array(CompositeAnimation.t) => CompositeAnimation.t = "";
+external sequence : array(Animation.t) => Animation.t = "";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external parallel :
-  (array(CompositeAnimation.t), {. "stopTogether": bool}) =>
-  CompositeAnimation.t =
+  (array(Animation.t), {. "stopTogether": bool}) => Animation.t =
   "";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external stagger :
-  (float, array(CompositeAnimation.t)) => CompositeAnimation.t =
-  "";
+external stagger : (float, array(Animation.t)) => Animation.t = "";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external _loop :
-  (CompositeAnimation.t, {. "iterations": int}) => CompositeAnimation.t =
-  "loop";
+external _loop : (Animation.t, {. "iterations": int}) => Animation.t = "loop";
 
 let loop = (~iterations=(-1), ~animation, ()) =>
   _loop(animation, {"iterations": iterations});
@@ -383,6 +382,17 @@ external createAnimatedComponent :
   ReasonReact.reactClass => ReasonReact.reactClass =
   "";
 
+let timing = Value.Timing.animate;
+
+let spring = Value.Spring.animate;
+
+let decay = Value.Decay.animate;
+
+/* Legacy, to prevent breaking changes */
+module Easing = Easing;
+
+module CompositeAnimation = Animation;
+
 module Timing = Value.Timing;
 
 module TimingXY = ValueXY.Timing;
@@ -394,5 +404,3 @@ module SpringXY = ValueXY.Spring;
 module Decay = Value.Decay;
 
 module DecayXY = ValueXY.Decay;
-
-module Easing = Easing;

--- a/src/animatedRe.re
+++ b/src/animatedRe.re
@@ -388,6 +388,8 @@ let spring = Value.Spring.animate;
 
 let decay = Value.Decay.animate;
 
+include Animation;
+
 /* Legacy, to prevent breaking changes */
 module Easing = Easing;
 

--- a/src/animatedRe.rei
+++ b/src/animatedRe.rei
@@ -1,18 +1,17 @@
 type calculated;
+
 type regular;
+
 type value('a);
+
 type valueXY('a);
 
 module Animation: {
   type t;
   type endResult = {. "finished": bool};
   type endCallback = endResult => unit;
-};
-
-module CompositeAnimation: {
-  type t;
   let stop: t => unit;
-  let start: (t, ~callback: Animation.endCallback=?, unit) => unit;
+  let start: (t, ~callback: endCallback=?, unit) => unit;
   let reset: t => unit;
 };
 
@@ -80,7 +79,7 @@ module Value: {
         ~iterations: int=?,
         unit
       ) =>
-      CompositeAnimation.t;
+      Animation.t;
   };
   module Spring: {
     type config;
@@ -105,7 +104,7 @@ module Value: {
         ~iterations: int=?,
         unit
       ) =>
-      CompositeAnimation.t;
+      Animation.t;
   };
   module Decay: {
     type config;
@@ -120,7 +119,7 @@ module Value: {
         ~iterations: int=?,
         unit
       ) =>
-      CompositeAnimation.t;
+      Animation.t;
   };
   let add: (value('a), value('b)) => value(calculated);
   let divide: (value('a), value('b)) => value(calculated);
@@ -176,7 +175,7 @@ module ValueXY: {
         ~iterations: int=?,
         unit
       ) =>
-      CompositeAnimation.t;
+      Animation.t;
   };
   module Spring: {
     type config;
@@ -201,7 +200,7 @@ module ValueXY: {
         ~iterations: int=?,
         unit
       ) =>
-      CompositeAnimation.t;
+      Animation.t;
   };
   module Decay: {
     type config;
@@ -216,7 +215,7 @@ module ValueXY: {
         ~iterations: int=?,
         unit
       ) =>
-      CompositeAnimation.t;
+      Animation.t;
   };
 };
 
@@ -224,22 +223,70 @@ type animatedEvent;
 
 let event: (array('a), 'b) => animatedEvent;
 
-let delay: float => CompositeAnimation.t;
+let delay: float => Animation.t;
 
-let sequence: array(CompositeAnimation.t) => CompositeAnimation.t;
+let sequence: array(Animation.t) => Animation.t;
 
-let parallel:
-  (array(CompositeAnimation.t), {. "stopTogether": bool}) =>
-  CompositeAnimation.t;
+let parallel: (array(Animation.t), {. "stopTogether": bool}) => Animation.t;
 
-let stagger: (float, array(CompositeAnimation.t)) => CompositeAnimation.t;
+let stagger: (float, array(Animation.t)) => Animation.t;
 
-let loop:
-  (~iterations: int=?, ~animation: CompositeAnimation.t, unit) =>
-  CompositeAnimation.t;
+let loop: (~iterations: int=?, ~animation: Animation.t, unit) => Animation.t;
 
 let createAnimatedComponent: ReasonReact.reactClass => ReasonReact.reactClass;
 
+let timing:
+  (
+    ~value: value(regular),
+    ~toValue: [ | `raw(float) | `animated(value(regular))],
+    ~easing: Easing.t=?,
+    ~duration: float=?,
+    ~delay: float=?,
+    ~isInteraction: bool=?,
+    ~useNativeDriver: bool=?,
+    ~onComplete: Animation.endCallback=?,
+    ~iterations: int=?,
+    unit
+  ) =>
+  Animation.t;
+
+let spring:
+  (
+    ~value: value(regular),
+    ~toValue: [ | `raw(float) | `animated(value(regular))],
+    ~restDisplacementThreshold: float=?,
+    ~overshootClamping: bool=?,
+    ~restSpeedThreshold: float=?,
+    ~velocity: float=?,
+    ~bounciness: float=?,
+    ~speed: float=?,
+    ~tension: float=?,
+    ~friction: float=?,
+    ~stiffness: float=?,
+    ~mass: float=?,
+    ~damping: float=?,
+    ~isInteraction: bool=?,
+    ~useNativeDriver: bool=?,
+    ~onComplete: Animation.endCallback=?,
+    ~iterations: int=?,
+    unit
+  ) =>
+  Animation.t;
+
+let decay:
+  (
+    ~value: value(regular),
+    ~velocity: float,
+    ~deceleration: float=?,
+    ~isInteraction: bool=?,
+    ~useNativeDriver: bool=?,
+    ~onComplete: Animation.endCallback=?,
+    ~iterations: int=?,
+    unit
+  ) =>
+  Animation.t;
+
+/** Legacy interface */
 module Timing = Value.Timing;
 
 module TimingXY = ValueXY.Timing;
@@ -253,3 +300,5 @@ module Decay = Value.Decay;
 module DecayXY = ValueXY.Decay;
 
 module Easing = Easing;
+
+module CompositeAnimation = Animation;

--- a/src/animatedRe.rei
+++ b/src/animatedRe.rei
@@ -286,6 +286,12 @@ let decay:
   ) =>
   Animation.t;
 
+let stop: Animation.t => unit;
+
+let start: (Animation.t, ~callback: Animation.endCallback=?, unit) => unit;
+
+let reset: Animation.t => unit;
+
 /** Legacy interface */
 module Timing = Value.Timing;
 


### PR DESCRIPTION
This pull request changes the interface of Animated in a backwards-compatible manner (no APIs were deleted).

It simplifies the number of modules you have to work with as well as makes it more aligned with React Native semantics. 

Changelog:
- `CompositeAnimation` is now `Animation` (removed one empty interface)
- `Spring.animate` etc., are now top-level functions (`spring`), like `parallel` and others
- Added missing documentation and example placeholders for `Animated.event` and `Animated.createAnimatedComponent`.