### PR TITLE
Bindings for MaskedViewIOS

### DIFF
--- a/docs/masked-view-ios.md
+++ b/docs/masked-view-ios.md
@@ -1,5 +1,5 @@
 ---
-title: MaskedViewIOS (x)
+title: MaskedViewIOS
 ---
 
 ## Example of use

--- a/docs/masked-view-ios.md
+++ b/docs/masked-view-ios.md
@@ -2,6 +2,54 @@
 title: MaskedViewIOS
 ---
 
+Rendes the child view with a mask specified in the [`maskElement`](#maskelement) prop.
+
 ## Example of use
 
+The following example demonstrates rendering a View with red background behind a mask, defined as a `Basic mask` string.
+
+```reason
+let component = ReasonReact.statelessComponent("MyComponent");
+
+let make = _children => {
+  ...component,
+  render: _self =>
+    <MaskedViewIOS
+      maskElement={
+        <View
+          style=Style.(
+                  style([
+                    flex(1.),
+                    justifyContent(Center),
+                    alignItems(Center),
+                    backgroundColor(String("transparent")),
+                  ])
+                )>
+          <Text
+            style=Style.(
+                    style([
+                      fontSize(Float(50.0)),
+                      color(String("black")),
+                      fontWeight(`_700),
+                    ])
+                  )>
+            (ReasonReact.string("Basic mask"))
+          </Text>
+        </View>
+      }>
+				<View
+					style=Style.(style([flex(1.), backgroundColor(String("red"))]))
+				/>
+		  </MaskedViewIOS>,
+};
+```
+
+See more examples in [RN docs](https://facebook.github.io/react-native/docs/maskedviewios#example).
+
 ## Props
+
+All [View](/docs/View.html#props) props are accepted.
+
+### maskElement
+
+

--- a/docs/masked-view-ios.md
+++ b/docs/masked-view-ios.md
@@ -37,10 +37,10 @@ let make = _children => {
           </Text>
         </View>
       }>
-				<View
-					style=Style.(style([flex(1.), backgroundColor(String("red"))]))
-				/>
-		  </MaskedViewIOS>,
+        <View
+          style=Style.(style([flex(1.), backgroundColor(String("red"))]))
+        />
+      </MaskedViewIOS>,
 };
 ```
 

--- a/src/components/maskedViewIOS.re
+++ b/src/components/maskedViewIOS.re
@@ -1,9 +1,9 @@
 [@bs.module "react-native"]
-external progressViewIOS : ReasonReact.reactClass = "MaskedViewIOS";
+external view : ReasonReact.reactClass = "MaskedViewIOS";
 
 let make =
     (
-      ~maskElement,
+      ~maskElement: ReasonReact.reactElement,
       ~accessible=?,
       ~accessibilityLabel=?,
       ~accessibilityComponentType=?,
@@ -26,7 +26,7 @@ let make =
       ~shouldRasterizeIOS=?,
     ) =>
   ReasonReact.wrapJsForReason(
-    ~reactClass=progressViewIOS,
+    ~reactClass=view,
     ~props=
       Props.extendView(
         ~accessibilityLabel?,

--- a/src/components/maskedViewIOS.re
+++ b/src/components/maskedViewIOS.re
@@ -1,0 +1,54 @@
+[@bs.module "react-native"]
+external progressViewIOS : ReasonReact.reactClass = "MaskedViewIOS";
+
+let make =
+    (
+      ~maskElement,
+      ~accessible=?,
+      ~accessibilityLabel=?,
+      ~accessibilityComponentType=?,
+      ~accessibilityTraits=?,
+      ~onAccessibilityTap=?,
+      ~hitSlop=?,
+      ~onLayout=?,
+      ~onMagicTap=?,
+      ~responderHandlers=?,
+      ~pointerEvents=?,
+      ~removeClippedSubviews=?,
+      ~style=?,
+      ~testID=?,
+      ~accessibilityLiveRegion=?,
+      ~collapsable=?,
+      ~importantForAccessibility=?,
+      ~needsOffscreenAlphaCompositing=?,
+      ~renderToHardwareTextureAndroid=?,
+      ~accessibilityViewIsModal=?,
+      ~shouldRasterizeIOS=?,
+    ) =>
+  ReasonReact.wrapJsForReason(
+    ~reactClass=progressViewIOS,
+    ~props=
+      Props.extendView(
+        ~accessibilityLabel?,
+        ~accessible?,
+        ~hitSlop?,
+        ~onAccessibilityTap?,
+        ~onLayout?,
+        ~onMagicTap?,
+        ~responderHandlers?,
+        ~pointerEvents?,
+        ~removeClippedSubviews?,
+        ~style?,
+        ~testID?,
+        ~accessibilityComponentType?,
+        ~accessibilityLiveRegion?,
+        ~collapsable?,
+        ~importantForAccessibility?,
+        ~needsOffscreenAlphaCompositing?,
+        ~renderToHardwareTextureAndroid?,
+        ~accessibilityTraits?,
+        ~accessibilityViewIsModal?,
+        ~shouldRasterizeIOS?,
+        Js.Undefined.({"maskElement": maskElement}),
+      ),
+  );

--- a/src/components/maskedViewIOS.rei
+++ b/src/components/maskedViewIOS.rei
@@ -1,0 +1,57 @@
+let make:
+  (
+    ~maskElement: 'a,
+    ~accessible: 'b=?,
+    ~accessibilityLabel: 'c=?,
+    ~accessibilityComponentType: [<
+                                   | `button
+                                   | `none
+                                   | `radiobutton_checked
+                                   | `radiobutton_unchecked
+                                 ]
+                                   =?,
+    ~accessibilityTraits: list(
+                            [<
+                              | `adjustable
+                              | `allowsDirectInteraction
+                              | `button
+                              | `disabled
+                              | `frequentUpdates
+                              | `header
+                              | `image
+                              | `key
+                              | `link
+                              | `none
+                              | `pageTurn
+                              | `plays
+                              | `search
+                              | `selected
+                              | `startsMedia
+                              | `summary
+                              | `text
+                            ],
+                          )
+                            =?,
+    ~onAccessibilityTap: 'd=?,
+    ~hitSlop: 'e=?,
+    ~onLayout: 'f=?,
+    ~onMagicTap: 'g=?,
+    ~responderHandlers: Rebolt.Types.touchResponderHandlers=?,
+    ~pointerEvents: [< | `auto | `boxNone | `boxOnly | `none]=?,
+    ~removeClippedSubviews: 'h=?,
+    ~style: 'i=?,
+    ~testID: 'j=?,
+    ~accessibilityLiveRegion: [< | `assertive | `none | `polite]=?,
+    ~collapsable: 'k=?,
+    ~importantForAccessibility: [< | `auto | `no | `noHideDescendants | `yes]=?,
+    ~needsOffscreenAlphaCompositing: 'l=?,
+    ~renderToHardwareTextureAndroid: 'm=?,
+    ~accessibilityViewIsModal: 'n=?,
+    ~shouldRasterizeIOS: 'o=?,
+    'p
+  ) =>
+  ReasonReact.component(
+    ReasonReact.stateless,
+    ReasonReact.noRetainedProps,
+    ReasonReact.actionless,
+  );

--- a/src/components/maskedViewIOS.rei
+++ b/src/components/maskedViewIOS.rei
@@ -1,17 +1,30 @@
 let make:
   (
-    ~maskElement: 'a,
-    ~accessible: 'b=?,
-    ~accessibilityLabel: 'c=?,
-    ~accessibilityComponentType: [<
+    ~accessibilityLabel: string=?,
+    ~accessible: bool=?,
+    ~hitSlop: Types.insets=?,
+    ~onAccessibilityTap: unit => unit=?,
+    ~onLayout: RNEvent.NativeLayoutEvent.t => unit=?,
+    ~onMagicTap: unit => unit=?,
+    ~responderHandlers: Types.touchResponderHandlers=?,
+    ~pointerEvents: [ | `auto | `boxNone | `boxOnly | `none]=?,
+    ~removeClippedSubviews: bool=?,
+    ~style: Style.t=?,
+    ~testID: string=?,
+    ~accessibilityComponentType: [
                                    | `button
                                    | `none
                                    | `radiobutton_checked
                                    | `radiobutton_unchecked
                                  ]
                                    =?,
+    ~accessibilityLiveRegion: [ | `assertive | `none | `polite]=?,
+    ~collapsable: bool=?,
+    ~importantForAccessibility: [ | `auto | `no | `noHideDescendants | `yes]=?,
+    ~needsOffscreenAlphaCompositing: bool=?,
+    ~renderToHardwareTextureAndroid: bool=?,
     ~accessibilityTraits: list(
-                            [<
+                            [
                               | `adjustable
                               | `allowsDirectInteraction
                               | `button
@@ -32,26 +45,12 @@ let make:
                             ],
                           )
                             =?,
-    ~onAccessibilityTap: 'd=?,
-    ~hitSlop: 'e=?,
-    ~onLayout: 'f=?,
-    ~onMagicTap: 'g=?,
-    ~responderHandlers: Rebolt.Types.touchResponderHandlers=?,
-    ~pointerEvents: [< | `auto | `boxNone | `boxOnly | `none]=?,
-    ~removeClippedSubviews: 'h=?,
-    ~style: 'i=?,
-    ~testID: 'j=?,
-    ~accessibilityLiveRegion: [< | `assertive | `none | `polite]=?,
-    ~collapsable: 'k=?,
-    ~importantForAccessibility: [< | `auto | `no | `noHideDescendants | `yes]=?,
-    ~needsOffscreenAlphaCompositing: 'l=?,
-    ~renderToHardwareTextureAndroid: 'm=?,
-    ~accessibilityViewIsModal: 'n=?,
-    ~shouldRasterizeIOS: 'o=?,
-    'p
+    ~accessibilityViewIsModal: bool=?,
+    ~shouldRasterizeIOS: bool=?,
+    array(ReasonReact.reactElement)
   ) =>
   ReasonReact.component(
     ReasonReact.stateless,
     ReasonReact.noRetainedProps,
-    ReasonReact.actionless,
+    unit,
   );

--- a/src/components/maskedViewIOS.rei
+++ b/src/components/maskedViewIOS.rei
@@ -1,16 +1,8 @@
 let make:
   (
-    ~accessibilityLabel: string=?,
+    ~maskElement: ReasonReact.reactElement,
     ~accessible: bool=?,
-    ~hitSlop: Types.insets=?,
-    ~onAccessibilityTap: unit => unit=?,
-    ~onLayout: RNEvent.NativeLayoutEvent.t => unit=?,
-    ~onMagicTap: unit => unit=?,
-    ~responderHandlers: Types.touchResponderHandlers=?,
-    ~pointerEvents: [ | `auto | `boxNone | `boxOnly | `none]=?,
-    ~removeClippedSubviews: bool=?,
-    ~style: Style.t=?,
-    ~testID: string=?,
+    ~accessibilityLabel: string=?,
     ~accessibilityComponentType: [
                                    | `button
                                    | `none
@@ -18,13 +10,8 @@ let make:
                                    | `radiobutton_unchecked
                                  ]
                                    =?,
-    ~accessibilityLiveRegion: [ | `assertive | `none | `polite]=?,
-    ~collapsable: bool=?,
-    ~importantForAccessibility: [ | `auto | `no | `noHideDescendants | `yes]=?,
-    ~needsOffscreenAlphaCompositing: bool=?,
-    ~renderToHardwareTextureAndroid: bool=?,
     ~accessibilityTraits: list(
-                            [
+                            [<
                               | `adjustable
                               | `allowsDirectInteraction
                               | `button
@@ -45,6 +32,20 @@ let make:
                             ],
                           )
                             =?,
+    ~onAccessibilityTap: unit => unit=?,
+    ~hitSlop: Types.insets=?,
+    ~onLayout: RNEvent.NativeLayoutEvent.t => unit=?,
+    ~onMagicTap: unit => unit=?,
+    ~responderHandlers: Types.touchResponderHandlers=?,
+    ~pointerEvents: [ | `auto | `boxNone | `boxOnly | `none]=?,
+    ~removeClippedSubviews: bool=?,
+    ~style: Style.t=?,
+    ~testID: string=?,
+    ~accessibilityLiveRegion: [ | `assertive | `none | `polite]=?,
+    ~collapsable: bool=?,
+    ~importantForAccessibility: [ | `auto | `no | `noHideDescendants | `yes]=?,
+    ~needsOffscreenAlphaCompositing: bool=?,
+    ~renderToHardwareTextureAndroid: bool=?,
     ~accessibilityViewIsModal: bool=?,
     ~shouldRasterizeIOS: bool=?,
     array(ReasonReact.reactElement)
@@ -52,5 +53,5 @@ let make:
   ReasonReact.component(
     ReasonReact.stateless,
     ReasonReact.noRetainedProps,
-    unit,
+    ReasonReact.actionless,
   );


### PR DESCRIPTION
Implements bindings for MaskedViewIOS - used in `rebolt-navigation` right now