### PR TITLE
Remove statusBarIOS from the documentation

### DIFF
--- a/docs/status-bar-ios.md
+++ b/docs/status-bar-ios.md
@@ -1,9 +1,0 @@
----
-title: StatusBarIOS (x)
----
-
-Missing bindings
-
-## Example of use
-
-## Function parameters

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -75,7 +75,6 @@
       "settings",
       "shadow-props",
       "share",
-      "status-bar-ios",
       "style-sheet",
       "systrace",
       "text-style-props",


### PR DESCRIPTION
Because of: https://github.com/facebook/react-native/commit/4de616b4c1a9d3556632a93504828f0539fa4fa5#diff-01152776ce61ce198b23c885195642de

